### PR TITLE
Add option to disable stability check

### DIFF
--- a/src/main/java/com/af/synapse/Settings.java
+++ b/src/main/java/com/af/synapse/Settings.java
@@ -16,12 +16,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 
-import com.af.synapse.utils.L;
 import com.af.synapse.utils.Utils;
 
 public class Settings extends PreferenceActivity {
     public final static String PREF_THEME   = "preference_list_theme_option";
     public final static String PREF_BOOT    = "preference_bool_boot_master";
+    public final static String PREF_PROBATION    = "preference_bool_boot_probation";
 
     public enum Theme {
         HOLO_BLACK,

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -38,7 +38,9 @@
 
     <string name="preference_category_boot_title">Boot service</string>
     <string name="preference_bool_boot_master_title">Apply on boot</string>
-    <string name="preference_bool_boot_master_summary">Master switch for the boot service. This does not control the underlying boot-stability flag that may be triggered on a crash.</string>
+    <string name="preference_bool_boot_master_summary">Master switch for the boot service.</string>
+    <string name="preference_bool_boot_probation_title">Stability check</string>
+    <string name="preference_bool_boot_probation_summary">Revert all changes if the device crashes or is powered off within 2 minutes after boot.</string>
 
     <string name="preference_category_theme_title">Theme</string>
 

--- a/src/main/res/xml/preference_main.xml
+++ b/src/main/res/xml/preference_main.xml
@@ -10,6 +10,13 @@
             android:title="@string/preference_bool_boot_master_title"
             android:summary="@string/preference_bool_boot_master_summary"
             android:defaultValue="true"/>
+
+        <CheckBoxPreference
+            android:key="preference_bool_boot_probation"
+            android:title="@string/preference_bool_boot_probation_title"
+            android:summary="@string/preference_bool_boot_probation_summary"
+            android:defaultValue="true"
+            android:dependency="preference_bool_boot_master"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
The two-minute stability check is very aggressive in that it runs after every boot, not just the first one after a change is made. This means something as simple as manually rebooting within two minutes after boot will *always* cause Synapse settings to be reset, even if they have been running stable for months. This change allows the user to manually prevent this from happening if they feel comfortable with their settings.

![screenshot_2015-03-22-13-46-18](https://cloud.githubusercontent.com/assets/308969/6769400/e4d98a8e-d099-11e4-8045-d9cc36c0fbeb.png)
