### PR TITLE
Fix for issue 52

### DIFF
--- a/src/main/java/com/af/synapse/MainActivity.java
+++ b/src/main/java/com/af/synapse/MainActivity.java
@@ -14,6 +14,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
@@ -117,6 +118,9 @@ public class MainActivity extends FragmentActivity {
         setPaddingDimensions();
         setContentView(R.layout.activity_loading);
 
+        if (!Utils.appStarted)
+            this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+
         super.onCreate(fragments == null ? null : savedInstanceState);
 
         if (fragments == null) {
@@ -188,6 +192,9 @@ public class MainActivity extends FragmentActivity {
 
         setPaddingDimensions();
         L.i("Interface creation finished in " + (System.nanoTime() - startTime) + "ns");
+
+        if (Utils.appStarted)
+            this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
 
         if (!BootService.getBootFlag() && !BootService.getBootFlagPending()) {
             new AlertDialog.Builder(this)

--- a/src/main/java/com/af/synapse/MyPreferenceFragment.java
+++ b/src/main/java/com/af/synapse/MyPreferenceFragment.java
@@ -1,0 +1,34 @@
+package com.af.synapse;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.af.synapse.utils.Utils;
+
+
+public class MyPreferenceFragment extends PreferenceFragment {
+
+    public MyPreferenceFragment() {
+        super();
+    }
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        PreferenceManager.setDefaultValues(Utils.settingsActivity, R.xml.preference_main, true);
+        addPreferencesFromResource(R.xml.preference_main);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup root, Bundle savedInstanceState){
+        View v = super.onCreateView(inflater, root, savedInstanceState);
+        if (v != null)
+            v.setPadding(0, MainActivity.topPadding, 0, 0);
+        return v;
+    }
+}

--- a/src/main/java/com/af/synapse/Settings.java
+++ b/src/main/java/com/af/synapse/Settings.java
@@ -7,13 +7,9 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
-import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 
 import com.af.synapse.utils.Utils;
@@ -128,23 +124,5 @@ public class Settings extends PreferenceActivity {
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    public class MyPreferenceFragment extends PreferenceFragment {
-        @Override
-        public void onCreate(final Bundle savedInstanceState)
-        {
-            super.onCreate(savedInstanceState);
-            PreferenceManager.setDefaultValues(Settings.this, R.xml.preference_main, true);
-            addPreferencesFromResource(R.xml.preference_main);
-        }
-
-        @Override
-        public View onCreateView(LayoutInflater inflater, ViewGroup root, Bundle savedInstanceState){
-            View v = super.onCreateView(inflater, root, savedInstanceState);
-            if (v != null)
-                v.setPadding(0, MainActivity.topPadding, 0, 0);
-            return v;
-        }
     }
 }


### PR DESCRIPTION
Fixes #52 

Logcat showed that error happened while invoking onConfigurationChanged method in mDrawerToggle, but didn't provide crash info.
Forcing portrait layout until all fragments have been loaded fixes rotation bug on loading app.

setRequestedOrientation will block invoking onConfigurationChanged for orientation events, but screenSize changes when orientation is changed will invoke it, thus avoiding this bug and properly notifying mDrawerToggle.

Forcing orientation made (or rather exposed what was happening in #52 ) new bug. Each time user rotated screen while in settings menu, Synapse would crash with InstantiationException for MyPreferenceFragment.

I fixed this by moving MyPreferenceFragment class to separate file and passing settings activity context via variable Utils.settingsActivity.

This effectively fixed all bugs I have noticed related to #52 
